### PR TITLE
Show creator username on shared link page

### DIFF
--- a/app/templates/shares/view.html
+++ b/app/templates/shares/view.html
@@ -52,7 +52,10 @@
                 {% endif %}
 
                 <div class="mt-6 pt-4 border-t border-gray-200 text-center text-xs text-gray-400">
-                    This share link expires {{ share.expires_at.strftime('%B %d, %Y at %H:%M UTC') }}
+                    {% if share.creator %}
+                    <p>Shared by {{ share.creator.username }}</p>
+                    {% endif %}
+                    <p>This share link expires {{ share.expires_at.strftime('%B %d, %Y at %H:%M UTC') }}</p>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Display the username of the user who created the share link in the footer of the shared view page. Hidden when no creator is set.